### PR TITLE
Updated extract-files.sh to skip files when they do not exist on device.

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -28,7 +28,11 @@ for FILE in `egrep -v '(^#|^$)' ../$DEVICE/device-proprietary-files.txt`; do
     mkdir -p $BASE/$DIR
   fi
   if [ "$SRC" = "adb" ]; then
-    adb pull /system/$FILE $BASE/$FILE
+    if adb pull /system/$FILE $BASE/$FILE 2> /dev/null; then
+	echo "Extraction was successful."
+    else
+	echo "Extracting /system/$FILE failed. Skipping ... "
+    fi
   else
     cp $SRC/system/$FILE $BASE/$FILE
   fi


### PR DESCRIPTION
This adds a fix to skips files when they do not exist on the device. Normally the process ends due to the return value from `adb` however now it notifies the user and continues checking for files to extract.
